### PR TITLE
Add def to avoid double STB implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,9 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-include(dgtal)
 include(polyscope)
+add_definitions(-DNO_ADD_STBIMAGE_IMPLEMENT)
+include(dgtal)
 
 include_directories(${DGTAL_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
Mainly to avoid double included implementation one from DGTal and the other one of pollyscope. Works with PR [#1666](https://github.com/DGtal-team/DGtal/pull/1666)